### PR TITLE
Remove pattern from pattern match

### DIFF
--- a/thirtythree.lua
+++ b/thirtythree.lua
@@ -7,7 +7,7 @@ mode_debug=true
 --json
 print(_VERSION)
 print(package.cpath)
-if not string.find(package.cpath,"/home/we/dust/code/thirtythree/lib/") then
+if not string.find(package.cpath,"/home/we/dust/code/thirtythree/lib/", 1, true) then
   package.cpath=package.cpath..";/home/we/dust/code/thirtythree/lib/?.so"
 end
 json=require("cjson")


### PR DESCRIPTION
I copied this code and while I think it doesn't matter here I found that it was doing a pattern-match on the library path. So my library had a "-" in it and thus it didn't match, kept adding in the path. This uses some optional arguments to `find` that forces it to a literal match. Figured if someone else tries this they might also get confused :)